### PR TITLE
Fix the phantom voltage filter for all inverter models

### DIFF
--- a/custom_components/ef_powerocean_tcpmodbus/binary_sensor.py
+++ b/custom_components/ef_powerocean_tcpmodbus/binary_sensor.py
@@ -44,7 +44,7 @@ class EcoFlowBinarySensor(CoordinatorEntity[EcoflowCoordinator], BinarySensorEnt
             identifiers={(DOMAIN, entry.entry_id)},
             name="EcoFlow PowerOcean",
             manufacturer="EcoFlow",
-            model="PowerOcean",
+            model=coordinator.inverter_model.display_name,
             serial_number=coordinator.serial_number,
             entry_type=DeviceEntryType.SERVICE,
         )

--- a/custom_components/ef_powerocean_tcpmodbus/config_flow.py
+++ b/custom_components/ef_powerocean_tcpmodbus/config_flow.py
@@ -11,7 +11,11 @@ from pymodbus.client import AsyncModbusTcpClient
 from homeassistant.core import callback
 from homeassistant.config_entries import ConfigFlow, ConfigEntry, OptionsFlow
 from homeassistant.data_entry_flow import FlowResult
-from homeassistant.helpers.selector import BooleanSelector
+from homeassistant.helpers.selector import (
+    BooleanSelector,
+    SelectSelector,
+    SelectSelectorConfig,
+)
 
 from .const import (
     DOMAIN,
@@ -22,11 +26,14 @@ from .const import (
     CONF_MAX_SOLAR_POWER,
     CONF_SCAN_INTERVAL,
     CONF_CALC_SOLAR_POWER,
+    CONF_INVERTER_MODEL,
     DEFAULT_PORT,
     DEFAULT_SCAN_INTERVAL,
     DEFAULT_BATTERY_COUNT,
     DEFAULT_MAX_GRID_POWER,
     DEFAULT_MAX_SOLAR_POWER,
+    DEFAULT_INVERTER_MODEL,
+    InverterModel,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -104,6 +111,14 @@ class EcoflowConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="parameters",
             data_schema=vol.Schema(
                 {
+                    vol.Required(
+                        CONF_INVERTER_MODEL, default=DEFAULT_INVERTER_MODEL
+                    ): SelectSelector(
+                        SelectSelectorConfig(
+                            options=[model.value for model in InverterModel],
+                            translation_key=CONF_INVERTER_MODEL,
+                        )
+                    ),
                     vol.Required(
                         CONF_BATTERY_COUNT, default=DEFAULT_BATTERY_COUNT
                     ): vol.All(int, vol.Range(min=0, max=6)),
@@ -187,6 +202,17 @@ class EcoflowOptionsFlow(OptionsFlow):
             step_id="parameters",
             data_schema=vol.Schema(
                 {
+                    vol.Required(
+                        CONF_INVERTER_MODEL,
+                        default=self._config_entry.data.get(
+                            CONF_INVERTER_MODEL, DEFAULT_INVERTER_MODEL
+                        ),
+                    ): SelectSelector(
+                        SelectSelectorConfig(
+                            options=[model.value for model in InverterModel],
+                            translation_key=CONF_INVERTER_MODEL,
+                        )
+                    ),
                     vol.Required(
                         CONF_BATTERY_COUNT,
                         default=self._config_entry.data.get(

--- a/custom_components/ef_powerocean_tcpmodbus/const.py
+++ b/custom_components/ef_powerocean_tcpmodbus/const.py
@@ -3,29 +3,62 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import StrEnum
+from typing import Final
 
-DOMAIN = "ef_powerocean_tcpmodbus"
-DEFAULT_PORT = 502
-DEFAULT_SLAVE = 1
-DEFAULT_SCAN_INTERVAL = 5  # seconds
-DEFAULT_BATTERY_COUNT = 0
-DEFAULT_MAX_SOLAR_POWER = 12000
-DEFAULT_MAX_GRID_POWER = 15000
-DEFAULT_MAX_POWER = 30000
+DOMAIN: Final = "ef_powerocean_tcpmodbus"
+DEFAULT_PORT: Final = 502
+DEFAULT_SLAVE: Final = 1
+DEFAULT_SCAN_INTERVAL: Final = 5  # seconds
+DEFAULT_BATTERY_COUNT: Final = 0
+DEFAULT_MAX_SOLAR_POWER: Final = 12000
+DEFAULT_MAX_GRID_POWER: Final = 15000
+DEFAULT_MAX_POWER: Final = 30000
 
-CONF_HOST = "host"
-CONF_PORT = "port"
-CONF_BATTERY_COUNT = "battery_count"
-CONF_MAX_SOLAR_POWER = "solar_power_max"
-CONF_MAX_GRID_POWER = "grid_power_max"
-CONF_MAX_BATTERY_CHARGED_POWER = "battery_charged_power_max"
-CONF_MAX_BATTERY_DISCHARGED_POWER = "battery_discharged_power_max"
-CONF_SCAN_INTERVAL = "scan_interval"
-CONF_CALC_SOLAR_POWER = "calc_solar_power"
+CONF_HOST: Final = "host"
+CONF_PORT: Final = "port"
+CONF_BATTERY_COUNT: Final = "battery_count"
+CONF_MAX_SOLAR_POWER: Final = "solar_power_max"
+CONF_MAX_GRID_POWER: Final = "grid_power_max"
+CONF_MAX_BATTERY_CHARGED_POWER: Final = "battery_charged_power_max"
+CONF_MAX_BATTERY_DISCHARGED_POWER: Final = "battery_discharged_power_max"
+CONF_SCAN_INTERVAL: Final = "scan_interval"
+CONF_CALC_SOLAR_POWER: Final = "calc_solar_power"
+CONF_INVERTER_MODEL: Final = "inverter_model"
 
-PV_VOLTAGE_THRESHOLD = 250
-MAX_BATTERY_CHARGED_POWER = 2500
-MAX_BATTERY_DISCHARGED_POWER = 3300
+MAX_BATTERY_CHARGED_POWER: Final = 2500
+MAX_BATTERY_DISCHARGED_POWER: Final = 3300
+
+
+class InverterModel(StrEnum):
+    POWEROCEAN_SINGLE_PHASE = "powerocean_single_phase"
+    POWEROCEAN_THREE_PHASE = "powerocean_three_phase"
+    POWEROCEAN_PLUS = "powerocean_plus"
+    OCEAN_2 = "ocean_2"
+
+    @property
+    def startup_voltage(self) -> int:
+        return {
+            # The startup voltage is used to filter out phantom string power when the PV input is not actually producing power.
+            # The values are based on the datasheets of each model. However, the single phase does not have a dedicated startup voltage specification
+            # so this value is deducted from the MPPT operating range.
+            self.POWEROCEAN_SINGLE_PHASE: 90,
+            self.POWEROCEAN_THREE_PHASE: 160,
+            self.POWEROCEAN_PLUS: 160,
+            self.OCEAN_2: 120,
+        }[self]
+
+    @property
+    def display_name(self) -> str:
+        return {
+            self.POWEROCEAN_SINGLE_PHASE: "PowerOcean Single Phase",
+            self.POWEROCEAN_THREE_PHASE: "PowerOcean Three Phase",
+            self.POWEROCEAN_PLUS: "PowerOcean Plus",
+            self.OCEAN_2: "Ocean 2",
+        }[self]
+
+
+DEFAULT_INVERTER_MODEL: Final = InverterModel.POWEROCEAN_THREE_PHASE
 
 
 @dataclass(frozen=True)

--- a/custom_components/ef_powerocean_tcpmodbus/const.py
+++ b/custom_components/ef_powerocean_tcpmodbus/const.py
@@ -34,6 +34,7 @@ class InverterModel(StrEnum):
     POWEROCEAN_SINGLE_PHASE = "powerocean_single_phase"
     POWEROCEAN_THREE_PHASE = "powerocean_three_phase"
     POWEROCEAN_PLUS = "powerocean_plus"
+    POWEROCEAN_DC_FIT = "powerocean_dc_fit"
     OCEAN_2 = "ocean_2"
 
     @property
@@ -42,10 +43,16 @@ class InverterModel(StrEnum):
             # The startup voltage is used to filter out phantom string power when the PV input is not actually producing power.
             # The values are based on the datasheets of each model. However, the single phase does not have a dedicated startup voltage specification
             # so this value is deducted from the MPPT operating range.
+            # https://enterprise-service-eu-cdn.ecoflow.com/enterprise/content/2024-03-27-1485da5d-eae4-4a38-830a-4e340517d968.pdf
             self.POWEROCEAN_SINGLE_PHASE: 90,
+            # https://enterprise-service-eu-cdn.ecoflow.com/enterprise/documentation/1772090325968/EcoFlow%20PowerOcean%20(Three-phase)_Datasheet_EN.pdf
             self.POWEROCEAN_THREE_PHASE: 160,
+            # https://enterprise-service-eu-cdn.ecoflow.com/enterprise/documentation/1754035729875/PowerOcean%20Plus%20(three-phase)_Brochure_20241223_EN.pdf
             self.POWEROCEAN_PLUS: 160,
-            self.OCEAN_2: 120,
+            # https://enterprise-service-eu-cdn.ecoflow.com/enterprise/documentation/1735192805714/EcoFlow%20PowerOcean%20DC%20Fit_Datasheet_EN_20241225.pdf
+            self.POWEROCEAN_DC_FIT: 90,
+            # https://enterprise-service-eu-cdn.ecoflow.com/enterprise/documentation/1779447439219/OCEAN%202%20Three-Phase_Datasheet_EN_260522.pdf
+            self.OCEAN_2: 120
         }[self]
 
     @property
@@ -54,6 +61,7 @@ class InverterModel(StrEnum):
             self.POWEROCEAN_SINGLE_PHASE: "PowerOcean Single Phase",
             self.POWEROCEAN_THREE_PHASE: "PowerOcean Three Phase",
             self.POWEROCEAN_PLUS: "PowerOcean Plus",
+            self.POWEROCEAN_DC_FIT: "PowerOcean DC Fit",
             self.OCEAN_2: "Ocean 2",
         }[self]
 

--- a/custom_components/ef_powerocean_tcpmodbus/coordinator.py
+++ b/custom_components/ef_powerocean_tcpmodbus/coordinator.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 import struct
 
-from typing import Any
+from typing import Any, Final
 from datetime import timedelta
 
 from datetime import datetime
@@ -48,8 +48,8 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-SLEEP_TIME_AFTER_RECONNECT = 1
-SLEEP_TIME_AFTER_BATTERY_CHECK_FAILED = 15
+SLEEP_TIME_AFTER_RECONNECT: Final = 1
+SLEEP_TIME_AFTER_BATTERY_CHECK_FAILED: Final = 15
 
 
 def getBit(value: int, bitpos: int) -> bool:

--- a/custom_components/ef_powerocean_tcpmodbus/coordinator.py
+++ b/custom_components/ef_powerocean_tcpmodbus/coordinator.py
@@ -30,7 +30,7 @@ from .const import (
     CONF_MAX_SOLAR_POWER,
     CONF_SCAN_INTERVAL,
     CONF_CALC_SOLAR_POWER,
-    PV_VOLTAGE_THRESHOLD,
+    CONF_INVERTER_MODEL,
     DEFAULT_SLAVE,
     ENERGY_SENSOR_MAP,
     MOD_REGISTER_MAP,
@@ -40,6 +40,8 @@ from .const import (
     DEFAULT_MAX_GRID_POWER,
     DEFAULT_MAX_SOLAR_POWER,
     DEFAULT_SCAN_INTERVAL,
+    DEFAULT_INVERTER_MODEL,
+    InverterModel,
     MAX_BATTERY_CHARGED_POWER,
     MAX_BATTERY_DISCHARGED_POWER,
 )
@@ -52,6 +54,15 @@ SLEEP_TIME_AFTER_BATTERY_CHECK_FAILED = 15
 
 def getBit(value: int, bitpos: int) -> bool:
     return (value & (2**bitpos)) == 2**bitpos
+
+
+def calculate_pv_power(
+    current: float | None, voltage: float | None, startup_voltage: int
+) -> float | None:
+    if current is None or voltage is None:
+        return None
+
+    return 0 if voltage < startup_voltage else round(current * voltage, 1)
 
 
 class EcoflowCoordinator(DataUpdateCoordinator):
@@ -87,6 +98,9 @@ class EcoflowCoordinator(DataUpdateCoordinator):
             * config_entry.data.get(CONF_BATTERY_COUNT, DEFAULT_BATTERY_COUNT),
         }
         self._ena_calc_solar_power = config_entry.data.get(CONF_CALC_SOLAR_POWER, False)
+        self.inverter_model = InverterModel(
+            config_entry.data.get(CONF_INVERTER_MODEL, DEFAULT_INVERTER_MODEL)
+        )
         super().__init__(
             hass,
             _LOGGER,
@@ -395,32 +409,15 @@ class EcoflowCoordinator(DataUpdateCoordinator):
         pv2_voltage = data.get("pv2_voltage", None)
         pv3_current = data.get("pv3_current", None)
         pv3_voltage = data.get("pv3_voltage", None)
-        calc_data["pv1_power"] = (
-            None
-            if pv1_current is None or pv1_voltage is None
-            else (
-                0
-                if pv1_voltage < PV_VOLTAGE_THRESHOLD
-                else round(pv1_current * pv1_voltage, 1)
-            )
+        startup_voltage = self.inverter_model.startup_voltage
+        calc_data["pv1_power"] = calculate_pv_power(
+            pv1_current, pv1_voltage, startup_voltage
         )
-        calc_data["pv2_power"] = (
-            None
-            if pv2_current is None or pv2_voltage is None
-            else (
-                0
-                if pv2_voltage < PV_VOLTAGE_THRESHOLD
-                else round(pv2_current * pv2_voltage, 1)
-            )
+        calc_data["pv2_power"] = calculate_pv_power(
+            pv2_current, pv2_voltage, startup_voltage
         )
-        calc_data["pv3_power"] = (
-            None
-            if pv3_current is None or pv3_voltage is None
-            else (
-                0
-                if pv3_voltage < PV_VOLTAGE_THRESHOLD
-                else round(pv3_current * pv3_voltage, 1)
-            )
+        calc_data["pv3_power"] = calculate_pv_power(
+            pv3_current, pv3_voltage, startup_voltage
         )
 
         if self._ena_calc_solar_power:

--- a/custom_components/ef_powerocean_tcpmodbus/coordinator.py
+++ b/custom_components/ef_powerocean_tcpmodbus/coordinator.py
@@ -62,7 +62,10 @@ def calculate_pv_power(
     if current is None or voltage is None:
         return None
 
-    return 0 if voltage < startup_voltage else round(current * voltage, 1)
+    if voltage < startup_voltage:
+        return 0.0
+
+    return round(current * voltage, 1)
 
 
 class EcoflowCoordinator(DataUpdateCoordinator):

--- a/custom_components/ef_powerocean_tcpmodbus/sensor.py
+++ b/custom_components/ef_powerocean_tcpmodbus/sensor.py
@@ -80,7 +80,7 @@ class EcoflowSensor(CoordinatorEntity[EcoflowCoordinator], RestoreSensor):
             identifiers={(DOMAIN, entry.entry_id)},
             name="EcoFlow PowerOcean",
             manufacturer="EcoFlow",
-            model="PowerOcean",
+            model=coordinator.inverter_model.display_name,
             serial_number=coordinator.serial_number,
             entry_type=DeviceEntryType.SERVICE,
         )

--- a/custom_components/ef_powerocean_tcpmodbus/sensor.py
+++ b/custom_components/ef_powerocean_tcpmodbus/sensor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from typing import Final
 import logging
 
 from homeassistant.components.sensor import RestoreSensor
@@ -33,7 +34,7 @@ from .coordinator import EcoflowCoordinator
 _LOGGER = logging.getLogger(__name__)
 
 
-VALUE_PRECISION = {
+VALUE_PRECISION: Final = {
     PERCENTAGE: 0,
     UnitOfPower.WATT: 0,
     UnitOfEnergy.KILO_WATT_HOUR: 2,

--- a/custom_components/ef_powerocean_tcpmodbus/strings.json
+++ b/custom_components/ef_powerocean_tcpmodbus/strings.json
@@ -86,6 +86,7 @@
         "powerocean_single_phase": "PowerOcean Single Phase",
         "powerocean_three_phase": "PowerOcean Three Phase",
         "powerocean_plus": "PowerOcean Plus",
+        "powerocean_dc_fit": "PowerOcean DC Fit",
         "ocean_2": "Ocean 2"
       }
     }

--- a/custom_components/ef_powerocean_tcpmodbus/strings.json
+++ b/custom_components/ef_powerocean_tcpmodbus/strings.json
@@ -17,6 +17,7 @@
         "title": "EcoFlow PowerOcean",
         "description": "Settings",
         "data": {
+          "inverter_model": "Inverter model",
           "battery_count": "Battery module count",
           "solar_power_max": "Maximum solar power [W]",
           "grid_power_max": "Maximum grid power [W]",
@@ -24,6 +25,7 @@
 		  "calc_solar_power": "Calculation of solar power"
         },
         "data_description": {
+          "inverter_model": "Select the Ecoflow inverter model.",
           "battery_count": "Count of your battery modules.",
           "solar_power_max": "Maximum solar power",
           "grid_power_max": "Maximum grid power",
@@ -57,6 +59,7 @@
         "title": "EcoFlow PowerOcean – Settings",
         "description": "Settings",
         "data": {
+          "inverter_model": "Inverter model",
           "battery_count": "Battery module count",
           "solar_power_max": "Maximum solar power [W]",
           "grid_power_max": "Maximum grid power [W]",
@@ -64,6 +67,7 @@
 		  "calc_solar_power": "Calculation of solar power"
         },
         "data_description": {
+          "inverter_model": "Select the Ecoflow inverter model.",
           "battery_count": "Count of your battery modules.",
           "solar_power_max": "Maximum solar power",
           "grid_power_max": "Maximum grid power",
@@ -76,6 +80,16 @@
       "cannot_connect": "Connection failed – please check IP address and port"
     }
   },
+	"selector": {
+		"inverter_model": {
+			"options": {
+				"powerocean_single_phase": "PowerOcean Single Phase",
+				"powerocean_three_phase": "PowerOcean Three Phase",
+				"powerocean_plus": "PowerOcean Plus",
+				"ocean_2": "Ocean 2"
+			}
+		}
+	},
   "entity":{
 	  "sensor": {
 		  "system_modes":{

--- a/custom_components/ef_powerocean_tcpmodbus/strings.json
+++ b/custom_components/ef_powerocean_tcpmodbus/strings.json
@@ -22,7 +22,7 @@
           "solar_power_max": "Maximum solar power [W]",
           "grid_power_max": "Maximum grid power [W]",
           "scan_interval": "Poll Interval [s]",
-		  "calc_solar_power": "Calculation of solar power"
+          "calc_solar_power": "Calculation of solar power"
         },
         "data_description": {
           "inverter_model": "Select the Ecoflow inverter model.",
@@ -30,12 +30,12 @@
           "solar_power_max": "Maximum solar power",
           "grid_power_max": "Maximum grid power",
           "scan_interval": "How often values are polled (2-30 seconds)",
-		  "calc_solar_power": "In some inverters, the modbus register delivers 0W of solar power. This switch allows the solar power to be calculated from the individual powers of the string."
+          "calc_solar_power": "In some inverters, the modbus register delivers 0W of solar power. This switch allows the solar power to be calculated from the individual powers of the string."
         }
       }
     },
     "error": {
-      "cannot_connect": "Connection failed – please check IP address and port"
+      "cannot_connect": "Connection failed - please check IP address and port"
     },
     "abort": {
       "already_configured": "This device is already configured"
@@ -44,7 +44,7 @@
   "options": {
     "step": {
       "init": {
-        "title": "EcoFlow PowerOcean – Settings",
+        "title": "EcoFlow PowerOcean - Settings",
         "description": "Adjust the connection details for your inverter.",
         "data": {
           "host": "IP Address",
@@ -56,7 +56,7 @@
         }
       },
       "parameters": {
-        "title": "EcoFlow PowerOcean – Settings",
+        "title": "EcoFlow PowerOcean - Settings",
         "description": "Settings",
         "data": {
           "inverter_model": "Inverter model",
@@ -64,188 +64,188 @@
           "solar_power_max": "Maximum solar power [W]",
           "grid_power_max": "Maximum grid power [W]",
           "scan_interval": "Poll Interval [s]",
-		  "calc_solar_power": "Calculation of solar power"
+          "calc_solar_power": "Calculation of solar power"
         },
         "data_description": {
           "inverter_model": "Select the Ecoflow inverter model.",
           "battery_count": "Count of your battery modules.",
           "solar_power_max": "Maximum solar power",
           "grid_power_max": "Maximum grid power",
-          "scan_interval": "How often values are polled (2–30 seconds)",
-		  "calc_solar_power": "In some inverters, the modbus register delivers 0W of solar power. This switch allows the solar power to be calculated from the individual powers of the string."
+          "scan_interval": "How often values are polled (2-30 seconds)",
+          "calc_solar_power": "In some inverters, the modbus register delivers 0W of solar power. This switch allows the solar power to be calculated from the individual powers of the string."
         }
       }
     },
     "error": {
-      "cannot_connect": "Connection failed – please check IP address and port"
+      "cannot_connect": "Connection failed - please check IP address and port"
     }
   },
-	"selector": {
-		"inverter_model": {
-			"options": {
-				"powerocean_single_phase": "PowerOcean Single Phase",
-				"powerocean_three_phase": "PowerOcean Three Phase",
-				"powerocean_plus": "PowerOcean Plus",
-				"ocean_2": "Ocean 2"
-			}
-		}
-	},
-  "entity":{
-	  "sensor": {
-		  "system_modes":{
-			  "name": "System Modes"
-		  },
-		"battery_count":{
-			  "name": "Battery Module Count"
-		  },
-		  "battery_soc":{
-			  "name": "Battery SOC"
-		  },
-      "soc_battery_1":{
-			  "name": "Battery 1 SOC"
-		  },
-      "soc_battery_2":{
-			  "name": "Battery 2 SOC"
-		  },
-      "soc_battery_3":{
-			  "name": "Battery 3 SOC"
-		  },
-		  "battery_power":{
-			  "name": "Battery Power"
-		  },
-		  "bat_remaining":{
-			  "name": "Battery Remaining Energy"
-		  },
-		  "battery_voltage":{
-			  "name": "Battery Voltage"
-		  },
-		  "battery_current":{
-			  "name": "Battery Current"
-		  },
-		  "battery_temperature":{
-			  "name": "Battery Temperature"
-		  },
-		  "battery_capacity":{
-			  "name": "Battery Nominal Capacity"
-		  },
-		  "min_soc_limit":{
-			  "name": "Min SOC Limit"
-		  },
-		  "bat_temp_warn_max":{
-			  "name": "Battery Temp Warning Max"
-		  },
-		  "device_led_brightness":{
-			  "name": "Device LED brightness"
-		  },
-		  "solar_power":{
-			  "name": "Solar Power"
-		  },
-		  "pv1_power":{
-			  "name": "PV String 1 Power"
-		  },
-		  "pv2_power":{
-			  "name": "PV String 2 Power"
-		  },
-		  "pv3_power":{
-			  "name": "PV String 3 Power"
-		  },
-		  "pv1_current":{
-			  "name": "PV String 1 Current"
-		  },
-		  "pv2_current":{
-			  "name": "PV String 2 Current"
-		  },
-		  "pv3_current":{
-			  "name": "PV String 3 Current"
-		  },
-		  "pv1_voltage":{
-			  "name": "PV String 1 Voltage"
-		  },
-		  "pv2_voltage":{
-			  "name": "PV String 2 Voltage"
-		  },
-		  "pv3_voltage":{
-			  "name": "PV String 3 Voltage"
-		  },
-		  "house_power":{
-			  "name": "House Power"
-		  },
-		  "grid_power":{
-			  "name": "Grid Power"
-		  },
-		  "voltage_l1":{
-			  "name": "Grid Voltage L1"
-		  },
-		  "voltage_l2":{
-			  "name": "Grid Voltage L2"
-		  },
-		  "voltage_l3":{
-			  "name": "Grid Voltage L3"
-		  },
-		  "current_l1":{
-			  "name": "Grid Current L1"
-		  },
-		  "current_l2":{
-			  "name": "Grid Current L2"
-		  },
-		  "current_l3":{
-			  "name": "Grid Current L3"
-		  },
-		  "frequency":{
-			  "name": "Grid Frequency"
-		  },
-		  "inverter_temperature":{
-			  "name": "Inverter Temperature"
-		  },
-		  "limit_inv_max":{
-			  "name": "Inverter Nominal Power Limit"
-		  },
-		  "limit_inv_power":{
-			  "name": "Inverter Current Max Power"
-		  },
-		  "house_energy_today":{
-			  "name": "House Consumption Today"
-		  },
-		  "solar_today":{
-			  "name": "Solar Yield Today"
-		  },
-		  "grid_import_today":{
-			  "name": "Grid Import Today"
-		  },
-		  "grid_export_today":{
-			  "name": "Grid Export Today"
-		  },
-		  "bat_charge_today":{
-			  "name": "Battery Charged Today"
-		  },
-		  "bat_discharge_today":{
-			  "name": "Battery Discharged Today"
-		  },
-		  "house_energy_total":{
-			  "name": "House Consumption Total"
-		  },
-		  "solar_total":{
-			  "name": "Solar Yield Total"
-		  },
-		  "grid_import_total":{
-			  "name": "Grid Import Total"
-		  },
-		  "grid_export_total":{
-			  "name": "Grid Export Total"
-		  },
-		  "bat_charged_total":{
-			  "name": "Battery Charged Total"
-		  },
-		  "bat_discharged_total":{
-			  "name": "Battery Discharged Total"
-		  },
-		  "bat_net_energy":{
-			  "name": "Battery Energy Loss"
-		  },
-		  "feed_in_power_max":{
-			  "name": "Maximum feed-in Power"
-		  }
-	  },
+  "selector": {
+    "inverter_model": {
+      "options": {
+        "powerocean_single_phase": "PowerOcean Single Phase",
+        "powerocean_three_phase": "PowerOcean Three Phase",
+        "powerocean_plus": "PowerOcean Plus",
+        "ocean_2": "Ocean 2"
+      }
+    }
+  },
+  "entity": {
+    "sensor": {
+      "system_modes": {
+        "name": "System Modes"
+      },
+      "battery_count": {
+        "name": "Battery Module Count"
+      },
+      "battery_soc": {
+        "name": "Battery SOC"
+      },
+      "soc_battery_1": {
+        "name": "Battery 1 SOC"
+      },
+      "soc_battery_2": {
+        "name": "Battery 2 SOC"
+      },
+      "soc_battery_3": {
+        "name": "Battery 3 SOC"
+      },
+      "battery_power": {
+        "name": "Battery Power"
+      },
+      "bat_remaining": {
+        "name": "Battery Remaining Energy"
+      },
+      "battery_voltage": {
+        "name": "Battery Voltage"
+      },
+      "battery_current": {
+        "name": "Battery Current"
+      },
+      "battery_temperature": {
+        "name": "Battery Temperature"
+      },
+      "battery_capacity": {
+        "name": "Battery Nominal Capacity"
+      },
+      "min_soc_limit": {
+        "name": "Min SOC Limit"
+      },
+      "bat_temp_warn_max": {
+        "name": "Battery Temp Warning Max"
+      },
+      "device_led_brightness": {
+        "name": "Device LED brightness"
+      },
+      "solar_power": {
+        "name": "Solar Power"
+      },
+      "pv1_power": {
+        "name": "PV String 1 Power"
+      },
+      "pv2_power": {
+        "name": "PV String 2 Power"
+      },
+      "pv3_power": {
+        "name": "PV String 3 Power"
+      },
+      "pv1_current": {
+        "name": "PV String 1 Current"
+      },
+      "pv2_current": {
+        "name": "PV String 2 Current"
+      },
+      "pv3_current": {
+        "name": "PV String 3 Current"
+      },
+      "pv1_voltage": {
+        "name": "PV String 1 Voltage"
+      },
+      "pv2_voltage": {
+        "name": "PV String 2 Voltage"
+      },
+      "pv3_voltage": {
+        "name": "PV String 3 Voltage"
+      },
+      "house_power": {
+        "name": "House Power"
+      },
+      "grid_power": {
+        "name": "Grid Power"
+      },
+      "voltage_l1": {
+        "name": "Grid Voltage L1"
+      },
+      "voltage_l2": {
+        "name": "Grid Voltage L2"
+      },
+      "voltage_l3": {
+        "name": "Grid Voltage L3"
+      },
+      "current_l1": {
+        "name": "Grid Current L1"
+      },
+      "current_l2": {
+        "name": "Grid Current L2"
+      },
+      "current_l3": {
+        "name": "Grid Current L3"
+      },
+      "frequency": {
+        "name": "Grid Frequency"
+      },
+      "inverter_temperature": {
+        "name": "Inverter Temperature"
+      },
+      "limit_inv_max": {
+        "name": "Inverter Nominal Power Limit"
+      },
+      "limit_inv_power": {
+        "name": "Inverter Current Max Power"
+      },
+      "house_energy_today": {
+        "name": "House Consumption Today"
+      },
+      "solar_today": {
+        "name": "Solar Yield Today"
+      },
+      "grid_import_today": {
+        "name": "Grid Import Today"
+      },
+      "grid_export_today": {
+        "name": "Grid Export Today"
+      },
+      "bat_charge_today": {
+        "name": "Battery Charged Today"
+      },
+      "bat_discharge_today": {
+        "name": "Battery Discharged Today"
+      },
+      "house_energy_total": {
+        "name": "House Consumption Total"
+      },
+      "solar_total": {
+        "name": "Solar Yield Total"
+      },
+      "grid_import_total": {
+        "name": "Grid Import Total"
+      },
+      "grid_export_total": {
+        "name": "Grid Export Total"
+      },
+      "bat_charged_total": {
+        "name": "Battery Charged Total"
+      },
+      "bat_discharged_total": {
+        "name": "Battery Discharged Total"
+      },
+      "bat_net_energy": {
+        "name": "Battery Energy Loss"
+      },
+      "feed_in_power_max": {
+        "name": "Maximum feed-in Power"
+      }
+    },
     "binary_sensor": {
       "self_use_mode_ena": {
         "name": "Self-powered Mode"

--- a/custom_components/ef_powerocean_tcpmodbus/translations/de.json
+++ b/custom_components/ef_powerocean_tcpmodbus/translations/de.json
@@ -17,6 +17,7 @@
         "title": "EcoFlow PowerOcean",
         "description": "Einstellungen",
         "data": {
+					"inverter_model": "Wechselrichtermodell",
           "battery_count": "Anzahl installierter Batterie-Module",
           "solar_power_max": "Maximale Solar-Leistung [W]",
           "grid_power_max": "Maximale Netz-Leistung [W]",
@@ -24,6 +25,7 @@
 		  "calc_solar_power": "Berechnung der Solarleistung"
         },
         "data_description": {
+					"inverter_model": "Wählen Sie das Wechselrichtermodell, damit die passende PV-Einschaltspannung zum Filtern von Phantomleistung verwendet wird.",
           "battery_count": "Die Anzahl wird zur Berechnung der max. Lade- und Entladeleistung verwendet.",
           "solar_power_max": "Die max. Solar-Leistung wird für die Überprüfung der empfangenen Werte verwendet.",
           "grid_power_max": "Die max. Netz-Leistung wird für die Überprüfung der empfangenen Werte verwendet.",
@@ -57,6 +59,7 @@
         "title": "EcoFlow PowerOcean – Einstellungen",
         "description": "Einstellungen",
         "data": {
+					"inverter_model": "Wechselrichtermodell",
           "battery_count": "Anzahl installierter Batterie-Module",
           "solar_power_max": "Maximale Solar-Leistung [W]",
           "grid_power_max": "Maximale Netz-Leistung [W]",
@@ -64,6 +67,7 @@
 		  "calc_solar_power": "Berechnung der Solarleistung"
         },
         "data_description": {
+					"inverter_model": "Wählen Sie das Wechselrichtermodell, damit die passende PV-Einschaltspannung zum Filtern von Phantomleistung verwendet wird.",
           "battery_count": "Die Anzahl wird zur Berechnung der max. Lade- und Entladeleistung verwendet.",
           "solar_power_max": "Die max. Solar-Leistung wird für die Überprüfung der empfangenen Werte verwendet.",
           "grid_power_max": "Die max. Netz-Leistung wird für die Überprüfung der empfangenen Werte verwendet.",
@@ -76,6 +80,16 @@
       "cannot_connect": "Verbindung fehlgeschlagen – IP-Adresse und Port prüfen"
     }
   },
+	"selector": {
+		"inverter_model": {
+			"options": {
+				"powerocean_single_phase": "PowerOcean einphasig",
+				"powerocean_three_phase": "PowerOcean dreiphasig",
+				"powerocean_plus": "PowerOcean Plus",
+				"ocean_2": "Ocean 2"
+			}
+		}
+	},
   "entity":{
 	  "sensor": {
 		  "system_modes":{

--- a/custom_components/ef_powerocean_tcpmodbus/translations/de.json
+++ b/custom_components/ef_powerocean_tcpmodbus/translations/de.json
@@ -17,7 +17,7 @@
         "title": "EcoFlow PowerOcean",
         "description": "Einstellungen",
         "data": {
-					"inverter_model": "Wechselrichtermodell",
+          "inverter_model": "Wechselrichtermodell",
           "battery_count": "Anzahl installierter Batterie-Module",
           "solar_power_max": "Maximale Solar-Leistung [W]",
           "grid_power_max": "Maximale Netz-Leistung [W]",
@@ -25,7 +25,7 @@
 		  "calc_solar_power": "Berechnung der Solarleistung"
         },
         "data_description": {
-					"inverter_model": "Wählen Sie das Wechselrichtermodell, damit die passende PV-Einschaltspannung zum Filtern von Phantomleistung verwendet wird.",
+          "inverter_model": "Wählen Sie das Wechselrichtermodell.",
           "battery_count": "Die Anzahl wird zur Berechnung der max. Lade- und Entladeleistung verwendet.",
           "solar_power_max": "Die max. Solar-Leistung wird für die Überprüfung der empfangenen Werte verwendet.",
           "grid_power_max": "Die max. Netz-Leistung wird für die Überprüfung der empfangenen Werte verwendet.",
@@ -67,7 +67,7 @@
 		  "calc_solar_power": "Berechnung der Solarleistung"
         },
         "data_description": {
-					"inverter_model": "Wählen Sie das Wechselrichtermodell, damit die passende PV-Einschaltspannung zum Filtern von Phantomleistung verwendet wird.",
+					"inverter_model": "Wählen Sie das Wechselrichtermodell.",
           "battery_count": "Die Anzahl wird zur Berechnung der max. Lade- und Entladeleistung verwendet.",
           "solar_power_max": "Die max. Solar-Leistung wird für die Überprüfung der empfangenen Werte verwendet.",
           "grid_power_max": "Die max. Netz-Leistung wird für die Überprüfung der empfangenen Werte verwendet.",
@@ -83,8 +83,8 @@
 	"selector": {
 		"inverter_model": {
 			"options": {
-				"powerocean_single_phase": "PowerOcean einphasig",
-				"powerocean_three_phase": "PowerOcean dreiphasig",
+				"powerocean_single_phase": "PowerOcean 1-phasig",
+				"powerocean_three_phase": "PowerOcean 3-phasig",
 				"powerocean_plus": "PowerOcean Plus",
 				"ocean_2": "Ocean 2"
 			}

--- a/custom_components/ef_powerocean_tcpmodbus/translations/de.json
+++ b/custom_components/ef_powerocean_tcpmodbus/translations/de.json
@@ -13,7 +13,7 @@
           "port": "Standard ist 502"
         }
       },
-      "parameters":{
+      "parameters": {
         "title": "EcoFlow PowerOcean",
         "description": "Einstellungen",
         "data": {
@@ -22,20 +22,20 @@
           "solar_power_max": "Maximale Solar-Leistung [W]",
           "grid_power_max": "Maximale Netz-Leistung [W]",
           "scan_interval": "Abfrageintervall [s]",
-		  "calc_solar_power": "Berechnung der Solarleistung"
+          "calc_solar_power": "Berechnung der Solarleistung"
         },
         "data_description": {
           "inverter_model": "Wählen Sie das Wechselrichtermodell.",
           "battery_count": "Die Anzahl wird zur Berechnung der max. Lade- und Entladeleistung verwendet.",
           "solar_power_max": "Die max. Solar-Leistung wird für die Überprüfung der empfangenen Werte verwendet.",
           "grid_power_max": "Die max. Netz-Leistung wird für die Überprüfung der empfangenen Werte verwendet.",
-          "scan_interval": "Wie oft Werte abgefragt werden (2–30 Sekunden)",
-		  "calc_solar_power": "Bei einigen Wechselrichtern liefert das Modbus-Register der Solarleistung 0W. Mit diesem Schalter kann die Solarleistung aus den Einzelleistungen der String berechnet werden."
+          "scan_interval": "Wie oft Werte abgefragt werden (2-30 Sekunden)",
+          "calc_solar_power": "Bei einigen Wechselrichtern liefert das Modbus-Register der Solarleistung 0W. Mit diesem Schalter kann die Solarleistung aus den Einzelleistungen der String berechnet werden."
         }
       }
     },
     "error": {
-      "cannot_connect": "Verbindung fehlgeschlagen – IP-Adresse und Port prüfen"
+      "cannot_connect": "Verbindung fehlgeschlagen - IP-Adresse und Port prüfen"
     },
     "abort": {
       "already_configured": "Dieses Gerät ist bereits eingerichtet"
@@ -44,7 +44,7 @@
   "options": {
     "step": {
       "init": {
-        "title": "EcoFlow PowerOcean – Einstellungen",
+        "title": "EcoFlow PowerOcean - Einstellungen",
         "description": "Verbindungsdaten",
         "data": {
           "host": "IP-Adresse",
@@ -56,196 +56,196 @@
         }
       },
       "parameters": {
-        "title": "EcoFlow PowerOcean – Einstellungen",
+        "title": "EcoFlow PowerOcean - Einstellungen",
         "description": "Einstellungen",
         "data": {
-					"inverter_model": "Wechselrichtermodell",
+          "inverter_model": "Wechselrichtermodell",
           "battery_count": "Anzahl installierter Batterie-Module",
           "solar_power_max": "Maximale Solar-Leistung [W]",
           "grid_power_max": "Maximale Netz-Leistung [W]",
           "scan_interval": "Abfrageintervall [s]",
-		  "calc_solar_power": "Berechnung der Solarleistung"
+          "calc_solar_power": "Berechnung der Solarleistung"
         },
         "data_description": {
-					"inverter_model": "Wählen Sie das Wechselrichtermodell.",
+          "inverter_model": "Wählen Sie das Wechselrichtermodell.",
           "battery_count": "Die Anzahl wird zur Berechnung der max. Lade- und Entladeleistung verwendet.",
           "solar_power_max": "Die max. Solar-Leistung wird für die Überprüfung der empfangenen Werte verwendet.",
           "grid_power_max": "Die max. Netz-Leistung wird für die Überprüfung der empfangenen Werte verwendet.",
-          "scan_interval": "Wie oft Werte abgefragt werden (2–30 Sekunden)",
-		  "calc_solar_power": "Bei einigen Wechselrichtern liefert das Modbus-Register der Solarleistung 0W. Mit diesem Schalter kann die Solarleistung aus den Einzelleistungen der String berechnet werden."
+          "scan_interval": "Wie oft Werte abgefragt werden (2-30 Sekunden)",
+          "calc_solar_power": "Bei einigen Wechselrichtern liefert das Modbus-Register der Solarleistung 0W. Mit diesem Schalter kann die Solarleistung aus den Einzelleistungen der String berechnet werden."
         }
       }
     },
     "error": {
-      "cannot_connect": "Verbindung fehlgeschlagen – IP-Adresse und Port prüfen"
+      "cannot_connect": "Verbindung fehlgeschlagen - IP-Adresse und Port prüfen"
     }
   },
-	"selector": {
-		"inverter_model": {
-			"options": {
-				"powerocean_single_phase": "PowerOcean 1-phasig",
-				"powerocean_three_phase": "PowerOcean 3-phasig",
-				"powerocean_plus": "PowerOcean Plus",
-				"ocean_2": "Ocean 2"
-			}
-		}
-	},
-  "entity":{
-	  "sensor": {
-		  "system_modes":{
-			  "name": "Betriebsmodi"
-		  },
-      "battery_count":{
-			  "name": "Batterieanzahl"
-		  },
-		  "battery_soc":{
-			  "name": "Batterieladezustand"
-		  },
-      "soc_battery_1":{
-			  "name": "Batterie 1 Ladezustand"
-		  },
-      "soc_battery_2":{
-			  "name": "Batterie 2 Ladezustand"
-		  },
-      "soc_battery_3":{
-			  "name": "Batterie 3 Ladezustand"
-		  },
-		  "battery_power":{
-			  "name": "Batterieleistung"
-		  },
-		  "bat_remaining":{
-			  "name": "Verbleibene Batterieladung"
-		  },
-		  "battery_voltage":{
-			  "name": "Batteriespannung"
-		  },
-		  "battery_current":{
-			  "name": "Batteriestrom"
-		  },
-		  "battery_temperature":{
-			  "name": "Batterietemperatur"
-		  },
-		  "battery_capacity":{
-			  "name": "Gesamt Batteriekapazität"
-		  },
-		  "min_soc_limit":{
-			  "name": "Batterie Backup-Reserve"
-		  },
-		  "bat_temp_warn_max":{
-			  "name": "Batterie Temp Warnung Max"
-		  },
-		  "device_led_brightness":{
-			  "name": "Helligkeit LED-Geräteanzeige"
-		  },
-		  "solar_power":{
-			  "name": "Solarleistung"
-		  },
-		  "pv1_power":{
-			  "name": "PV-Leistung String 1"
-		  },
-		  "pv2_power":{
-			  "name": "PV-Leistung String 2"
-		  },
-		  "pv3_power":{
-			  "name": "PV-Leistung String 3"
-		  },
-		  "pv1_current":{
-			  "name": "PV-Strom String 1"
-		  },
-		  "pv2_current":{
-			  "name": "PV-Strom String 2"
-		  },
-		  "pv3_current":{
-			  "name": "PV-Strom String 3"
-		  },
-		  "pv1_voltage":{
-			  "name": "PV-Spannung String 1"
-		  },
-		  "pv2_voltage":{
-			  "name": "PV-Spannung String 2"
-		  },
-		  "pv3_voltage":{
-			  "name": "PV-Spannung String 3"
-		  },
-		  "house_power":{
-			  "name": "Hausverbrauch"
-		  },
-		  "grid_power":{
-			  "name": "Netzleistung"
-		  },
-		  "voltage_l1":{
-			  "name": "Netz Phase L1 Spannung"
-		  },
-		  "voltage_l2":{
-			  "name": "Netz Phase L2 Spannung"
-		  },
-		  "voltage_l3":{
-			  "name": "Netz Phase L3 Spannung"
-		  },
-		  "current_l1":{
-			  "name": "Netz Phase L1 Strom"
+  "selector": {
+    "inverter_model": {
+      "options": {
+        "powerocean_single_phase": "PowerOcean 1-phasig",
+        "powerocean_three_phase": "PowerOcean 3-phasig",
+        "powerocean_plus": "PowerOcean Plus",
+        "ocean_2": "Ocean 2"
+      }
+    }
+  },
+  "entity": {
+    "sensor": {
+      "system_modes": {
+        "name": "Betriebsmodi"
       },
-		  "current_l2":{
-			  "name": "Netz Phase L2 Strom"
-		  },
-		  "current_l3":{
-			  "name": "Netz Phase L3 Strom"
-		  },
-		  "frequency":{
-			  "name": "Netzfrequenz"
-		  },
-		  "inverter_temperature":{
-			  "name": "Wechselrichter-Temperatur"
-		  },
-		  "limit_inv_max":{
-			  "name": "WR-Nennleistungsgrenze"
-		  },
-		  "limit_inv_power":{
-			  "name": "WR-Maximalleistung"
-		  },
-		  "house_energy_today":{
-			  "name": "Hausenergie Heute"
-		  },
-		  "solar_today":{
-			  "name": "Solarenergie Heute"
-		  },
-		  "grid_import_today":{
-			  "name": "Netzbezugsenergie Heute"
-		  },
-		  "grid_export_today":{
-			  "name": "Netzeinspeiseenergie Heute"
-		  },
-		  "bat_charged_today":{
-			  "name": "Batterieladeenergie Heute"
-		  },
-		  "bat_discharged_today":{
-			  "name": "Batterieentladeenergie Heute"
-		  },
-		  "house_energy_total":{
-			  "name": "Hausenergie Gesamt"
-		  },
-		  "solar_total":{
-			  "name": "Solarenergie Gesamt"
-		  },
-		  "grid_import_total":{
-			  "name": "Netzbezugsenergie Gesamt"
-		  },
-		  "grid_export_total":{
-			  "name": "Netzeinspeiseenergie Gesamt"
-		  },
-		  "bat_charged_total":{
-			  "name": "Batterieladeenergie Gesamt"
-		  },
-		  "bat_discharged_total":{
-			  "name": "Batterieentladeenergie Gesamt"
-		  },
-		  "bat_net_energy":{
-			  "name": "Batterieverlustenergie Gesamt"
-		  },
-		  "feed_in_power_max":{
-			  "name": "Max. Einspeiseleistung"
-		  }
-	  },
+      "battery_count": {
+        "name": "Batterieanzahl"
+      },
+      "battery_soc": {
+        "name": "Batterieladezustand"
+      },
+      "soc_battery_1": {
+        "name": "Batterie 1 Ladezustand"
+      },
+      "soc_battery_2": {
+        "name": "Batterie 2 Ladezustand"
+      },
+      "soc_battery_3": {
+        "name": "Batterie 3 Ladezustand"
+      },
+      "battery_power": {
+        "name": "Batterieleistung"
+      },
+      "bat_remaining": {
+        "name": "Verbleibene Batterieladung"
+      },
+      "battery_voltage": {
+        "name": "Batteriespannung"
+      },
+      "battery_current": {
+        "name": "Batteriestrom"
+      },
+      "battery_temperature": {
+        "name": "Batterietemperatur"
+      },
+      "battery_capacity": {
+        "name": "Gesamt Batteriekapazität"
+      },
+      "min_soc_limit": {
+        "name": "Batterie Backup-Reserve"
+      },
+      "bat_temp_warn_max": {
+        "name": "Batterie Temp Warnung Max"
+      },
+      "device_led_brightness": {
+        "name": "Helligkeit LED-Geräteanzeige"
+      },
+      "solar_power": {
+        "name": "Solarleistung"
+      },
+      "pv1_power": {
+        "name": "PV-Leistung String 1"
+      },
+      "pv2_power": {
+        "name": "PV-Leistung String 2"
+      },
+      "pv3_power": {
+        "name": "PV-Leistung String 3"
+      },
+      "pv1_current": {
+        "name": "PV-Strom String 1"
+      },
+      "pv2_current": {
+        "name": "PV-Strom String 2"
+      },
+      "pv3_current": {
+        "name": "PV-Strom String 3"
+      },
+      "pv1_voltage": {
+        "name": "PV-Spannung String 1"
+      },
+      "pv2_voltage": {
+        "name": "PV-Spannung String 2"
+      },
+      "pv3_voltage": {
+        "name": "PV-Spannung String 3"
+      },
+      "house_power": {
+        "name": "Hausverbrauch"
+      },
+      "grid_power": {
+        "name": "Netzleistung"
+      },
+      "voltage_l1": {
+        "name": "Netz Phase L1 Spannung"
+      },
+      "voltage_l2": {
+        "name": "Netz Phase L2 Spannung"
+      },
+      "voltage_l3": {
+        "name": "Netz Phase L3 Spannung"
+      },
+      "current_l1": {
+        "name": "Netz Phase L1 Strom"
+      },
+      "current_l2": {
+        "name": "Netz Phase L2 Strom"
+      },
+      "current_l3": {
+        "name": "Netz Phase L3 Strom"
+      },
+      "frequency": {
+        "name": "Netzfrequenz"
+      },
+      "inverter_temperature": {
+        "name": "Wechselrichter-Temperatur"
+      },
+      "limit_inv_max": {
+        "name": "WR-Nennleistungsgrenze"
+      },
+      "limit_inv_power": {
+        "name": "WR-Maximalleistung"
+      },
+      "house_energy_today": {
+        "name": "Hausenergie Heute"
+      },
+      "solar_today": {
+        "name": "Solarenergie Heute"
+      },
+      "grid_import_today": {
+        "name": "Netzbezugsenergie Heute"
+      },
+      "grid_export_today": {
+        "name": "Netzeinspeiseenergie Heute"
+      },
+      "bat_charged_today": {
+        "name": "Batterieladeenergie Heute"
+      },
+      "bat_discharged_today": {
+        "name": "Batterieentladeenergie Heute"
+      },
+      "house_energy_total": {
+        "name": "Hausenergie Gesamt"
+      },
+      "solar_total": {
+        "name": "Solarenergie Gesamt"
+      },
+      "grid_import_total": {
+        "name": "Netzbezugsenergie Gesamt"
+      },
+      "grid_export_total": {
+        "name": "Netzeinspeiseenergie Gesamt"
+      },
+      "bat_charged_total": {
+        "name": "Batterieladeenergie Gesamt"
+      },
+      "bat_discharged_total": {
+        "name": "Batterieentladeenergie Gesamt"
+      },
+      "bat_net_energy": {
+        "name": "Batterieverlustenergie Gesamt"
+      },
+      "feed_in_power_max": {
+        "name": "Max. Einspeiseleistung"
+      }
+    },
     "binary_sensor": {
       "self_use_mode_ena": {
         "name": "Eigenstromversorgung"

--- a/custom_components/ef_powerocean_tcpmodbus/translations/en.json
+++ b/custom_components/ef_powerocean_tcpmodbus/translations/en.json
@@ -17,25 +17,25 @@
         "title": "EcoFlow PowerOcean",
         "description": "Settings",
         "data": {
-					"inverter_model": "Inverter model",
+          "inverter_model": "Inverter model",
           "battery_count": "Battery module count",
           "solar_power_max": "Maximum solar power [W]",
           "grid_power_max": "Maximum grid power [W]",
           "scan_interval": "Poll Interval [s]",
-		  "calc_solar_power": "Calculation of solar power"
+          "calc_solar_power": "Calculation of solar power"
         },
         "data_description": {
-					"inverter_model": "Select the inverter model to use the correct PV startup voltage when filtering phantom string power.",
+          "inverter_model": "Select the inverter model.",
           "battery_count": "Count of your battery modules.",
           "solar_power_max": "Maximum solar power",
           "grid_power_max": "Maximum grid power",
           "scan_interval": "How often values are polled (2-30 seconds)",
-		  "calc_solar_power": "In some inverters, the modbus register delivers 0W of solar power. This switch allows the solar power to be calculated from the individual powers of the string."
+          "calc_solar_power": "In some inverters, the modbus register delivers 0W of solar power. This switch allows the solar power to be calculated from the individual powers of the string."
         }
       }
     },
     "error": {
-      "cannot_connect": "Connection failed – please check IP address and port"
+      "cannot_connect": "Connection failed - please check IP address and port"
     },
     "abort": {
       "already_configured": "This device is already configured"
@@ -44,7 +44,7 @@
   "options": {
     "step": {
       "init": {
-        "title": "EcoFlow PowerOcean – Settings",
+        "title": "EcoFlow PowerOcean - Settings",
         "description": "Adjust the connection details for your inverter.",
         "data": {
           "host": "IP Address",
@@ -56,196 +56,196 @@
         }
       },
       "parameters": {
-        "title": "EcoFlow PowerOcean – Settings",
+        "title": "EcoFlow PowerOcean - Settings",
         "description": "Settings",
         "data": {
-					"inverter_model": "Inverter model",
+          "inverter_model": "Inverter model",
           "battery_count": "Battery module count",
           "solar_power_max": "Maximum solar power [W]",
           "grid_power_max": "Maximum grid power [W]",
           "scan_interval": "Poll Interval [s]",
-		  "calc_solar_power": "Calculation of solar power"
+          "calc_solar_power": "Calculation of solar power"
         },
         "data_description": {
-					"inverter_model": "Select the inverter model to use the correct PV startup voltage when filtering phantom string power.",
+          "inverter_model": "Select the inverter model.",
           "battery_count": "Count of your battery modules.",
           "solar_power_max": "Maximum solar power",
           "grid_power_max": "Maximum grid power",
-          "scan_interval": "How often values are polled (2–30 seconds)",
-		  "calc_solar_power": "In some inverters, the modbus register delivers 0W of solar power. This switch allows the solar power to be calculated from the individual powers of the string."
+          "scan_interval": "How often values are polled (2-30 seconds)",
+          "calc_solar_power": "In some inverters, the modbus register delivers 0W of solar power. This switch allows the solar power to be calculated from the individual powers of the string."
         }
       }
     },
     "error": {
-      "cannot_connect": "Connection failed – please check IP address and port"
+      "cannot_connect": "Connection failed - please check IP address and port"
     }
   },
-	"selector": {
-		"inverter_model": {
-			"options": {
-				"powerocean_single_phase": "PowerOcean Single Phase",
-				"powerocean_three_phase": "PowerOcean Three Phase",
-				"powerocean_plus": "PowerOcean Plus",
-				"ocean_2": "Ocean 2"
-			}
-		}
-	},
-  "entity":{
-	  "sensor": {
-		  "system_modes":{
-			  "name": "System Modes"
-		  },
-		"battery_count":{
-			  "name": "Battery Module Count"
-		  },
-		  "battery_soc":{
-			  "name": "Battery SOC"
-		  },
-      "soc_battery_1":{
-			  "name": "Battery 1 SOC"
-		  },
-      "soc_battery_2":{
-			  "name": "Battery 2 SOC"
-		  },
-      "soc_battery_3":{
-			  "name": "Battery 3 SOC"
-		  },
-		  "battery_power":{
-			  "name": "Battery Power"
-		  },
-		  "bat_remaining":{
-			  "name": "Battery Remaining Energy"
-		  },
-		  "battery_voltage":{
-			  "name": "Battery Voltage"
-		  },
-		  "battery_current":{
-			  "name": "Battery Current"
-		  },
-		  "battery_temperature":{
-			  "name": "Battery Temperature"
-		  },
-		  "battery_capacity":{
-			  "name": "Battery Nominal Capacity"
-		  },
-		  "min_soc_limit":{
-			  "name": "Min SOC Limit"
-		  },
-		  "bat_temp_warn_max":{
-			  "name": "Battery Temp Warning Max"
-		  },
-		  "device_led_brightness":{
-			  "name": "Device LED brightness"
-		  },
-		  "solar_power":{
-			  "name": "Solar Power"
-		  },
-		  "pv1_power":{
-			  "name": "PV String 1 Power"
-		  },
-		  "pv2_power":{
-			  "name": "PV String 2 Power"
-		  },
-		  "pv3_power":{
-			  "name": "PV String 3 Power"
-		  },
-		  "pv1_current":{
-			  "name": "PV String 1 Current"
-		  },
-		  "pv2_current":{
-			  "name": "PV String 2 Current"
-		  },
-		  "pv3_current":{
-			  "name": "PV String 3 Current"
-		  },
-		  "pv1_voltage":{
-			  "name": "PV String 1 Voltage"
-		  },
-		  "pv2_voltage":{
-			  "name": "PV String 2 Voltage"
-		  },
-		  "pv3_voltage":{
-			  "name": "PV String 3 Voltage"
-		  },
-		  "house_power":{
-			  "name": "House Power"
-		  },
-		  "grid_power":{
-			  "name": "Grid Power"
-		  },
-		  "voltage_l1":{
-			  "name": "Grid Voltage L1"
-		  },
-		  "voltage_l2":{
-			  "name": "Grid Voltage L2"
-		  },
-		  "voltage_l3":{
-			  "name": "Grid Voltage L3"
-		  },
-		  "current_l1":{
-			  "name": "Grid Current L1"
-		  },
-		  "current_l2":{
-			  "name": "Grid Current L2"
-		  },
-		  "current_l3":{
-			  "name": "Grid Current L3"
-		  },
-		  "frequency":{
-			  "name": "Grid Frequency"
-		  },
-		  "inverter_temperature":{
-			  "name": "Inverter Temperature"
-		  },
-		  "limit_inv_max":{
-			  "name": "Inverter Nominal Power Limit"
-		  },
-		  "limit_inv_power":{
-			  "name": "Inverter Current Max Power"
-		  },
-		  "house_energy_today":{
-			  "name": "House Consumption Today"
-		  },
-		  "solar_today":{
-			  "name": "Solar Yield Today"
-		  },
-		  "grid_import_today":{
-			  "name": "Grid Import Today"
-		  },
-		  "grid_export_today":{
-			  "name": "Grid Export Today"
-		  },
-		  "bat_charged_today":{
-			  "name": "Battery Charged Today"
-		  },
-		  "bat_discharged_today":{
-			  "name": "Battery Discharged Today"
-		  },
-		  "house_energy_total":{
-			  "name": "House Consumption Total"
-		  },
-		  "solar_total":{
-			  "name": "Solar Yield Total"
-		  },
-		  "grid_import_total":{
-			  "name": "Grid Import Total"
-		  },
-		  "grid_export_total":{
-			  "name": "Grid Export Total"
-		  },
-		  "bat_charged_total":{
-			  "name": "Battery Charged Total"
-		  },
-		  "bat_discharged_total":{
-			  "name": "Battery Discharged Total"
-		  },
-		  "bat_net_energy":{
-			  "name": "Battery Energy Loss"
-		  },
-		  "feed_in_power_max":{
-			  "name": "Maximum feed-in Power"
-		  }
-	  },
+  "selector": {
+    "inverter_model": {
+      "options": {
+        "powerocean_single_phase": "PowerOcean Single Phase",
+        "powerocean_three_phase": "PowerOcean Three Phase",
+        "powerocean_plus": "PowerOcean Plus",
+        "ocean_2": "Ocean 2"
+      }
+    }
+  },
+  "entity": {
+    "sensor": {
+      "system_modes": {
+        "name": "System Modes"
+      },
+      "battery_count": {
+        "name": "Battery Module Count"
+      },
+      "battery_soc": {
+        "name": "Battery SOC"
+      },
+      "soc_battery_1": {
+        "name": "Battery 1 SOC"
+      },
+      "soc_battery_2": {
+        "name": "Battery 2 SOC"
+      },
+      "soc_battery_3": {
+        "name": "Battery 3 SOC"
+      },
+      "battery_power": {
+        "name": "Battery Power"
+      },
+      "bat_remaining": {
+        "name": "Battery Remaining Energy"
+      },
+      "battery_voltage": {
+        "name": "Battery Voltage"
+      },
+      "battery_current": {
+        "name": "Battery Current"
+      },
+      "battery_temperature": {
+        "name": "Battery Temperature"
+      },
+      "battery_capacity": {
+        "name": "Battery Nominal Capacity"
+      },
+      "min_soc_limit": {
+        "name": "Min SOC Limit"
+      },
+      "bat_temp_warn_max": {
+        "name": "Battery Temp Warning Max"
+      },
+      "device_led_brightness": {
+        "name": "Device LED brightness"
+      },
+      "solar_power": {
+        "name": "Solar Power"
+      },
+      "pv1_power": {
+        "name": "PV String 1 Power"
+      },
+      "pv2_power": {
+        "name": "PV String 2 Power"
+      },
+      "pv3_power": {
+        "name": "PV String 3 Power"
+      },
+      "pv1_current": {
+        "name": "PV String 1 Current"
+      },
+      "pv2_current": {
+        "name": "PV String 2 Current"
+      },
+      "pv3_current": {
+        "name": "PV String 3 Current"
+      },
+      "pv1_voltage": {
+        "name": "PV String 1 Voltage"
+      },
+      "pv2_voltage": {
+        "name": "PV String 2 Voltage"
+      },
+      "pv3_voltage": {
+        "name": "PV String 3 Voltage"
+      },
+      "house_power": {
+        "name": "House Power"
+      },
+      "grid_power": {
+        "name": "Grid Power"
+      },
+      "voltage_l1": {
+        "name": "Grid Voltage L1"
+      },
+      "voltage_l2": {
+        "name": "Grid Voltage L2"
+      },
+      "voltage_l3": {
+        "name": "Grid Voltage L3"
+      },
+      "current_l1": {
+        "name": "Grid Current L1"
+      },
+      "current_l2": {
+        "name": "Grid Current L2"
+      },
+      "current_l3": {
+        "name": "Grid Current L3"
+      },
+      "frequency": {
+        "name": "Grid Frequency"
+      },
+      "inverter_temperature": {
+        "name": "Inverter Temperature"
+      },
+      "limit_inv_max": {
+        "name": "Inverter Nominal Power Limit"
+      },
+      "limit_inv_power": {
+        "name": "Inverter Current Max Power"
+      },
+      "house_energy_today": {
+        "name": "House Consumption Today"
+      },
+      "solar_today": {
+        "name": "Solar Yield Today"
+      },
+      "grid_import_today": {
+        "name": "Grid Import Today"
+      },
+      "grid_export_today": {
+        "name": "Grid Export Today"
+      },
+      "bat_charged_today": {
+        "name": "Battery Charged Today"
+      },
+      "bat_discharged_today": {
+        "name": "Battery Discharged Today"
+      },
+      "house_energy_total": {
+        "name": "House Consumption Total"
+      },
+      "solar_total": {
+        "name": "Solar Yield Total"
+      },
+      "grid_import_total": {
+        "name": "Grid Import Total"
+      },
+      "grid_export_total": {
+        "name": "Grid Export Total"
+      },
+      "bat_charged_total": {
+        "name": "Battery Charged Total"
+      },
+      "bat_discharged_total": {
+        "name": "Battery Discharged Total"
+      },
+      "bat_net_energy": {
+        "name": "Battery Energy Loss"
+      },
+      "feed_in_power_max": {
+        "name": "Maximum feed-in Power"
+      }
+    },
     "binary_sensor": {
       "self_use_mode_ena": {
         "name": "Self-powered Mode"

--- a/custom_components/ef_powerocean_tcpmodbus/translations/en.json
+++ b/custom_components/ef_powerocean_tcpmodbus/translations/en.json
@@ -86,6 +86,7 @@
         "powerocean_single_phase": "PowerOcean Single Phase",
         "powerocean_three_phase": "PowerOcean Three Phase",
         "powerocean_plus": "PowerOcean Plus",
+        "powerocean_dc_fit": "PowerOcean DC Fit",
         "ocean_2": "Ocean 2"
       }
     }

--- a/custom_components/ef_powerocean_tcpmodbus/translations/en.json
+++ b/custom_components/ef_powerocean_tcpmodbus/translations/en.json
@@ -17,6 +17,7 @@
         "title": "EcoFlow PowerOcean",
         "description": "Settings",
         "data": {
+					"inverter_model": "Inverter model",
           "battery_count": "Battery module count",
           "solar_power_max": "Maximum solar power [W]",
           "grid_power_max": "Maximum grid power [W]",
@@ -24,6 +25,7 @@
 		  "calc_solar_power": "Calculation of solar power"
         },
         "data_description": {
+					"inverter_model": "Select the inverter model to use the correct PV startup voltage when filtering phantom string power.",
           "battery_count": "Count of your battery modules.",
           "solar_power_max": "Maximum solar power",
           "grid_power_max": "Maximum grid power",
@@ -57,6 +59,7 @@
         "title": "EcoFlow PowerOcean – Settings",
         "description": "Settings",
         "data": {
+					"inverter_model": "Inverter model",
           "battery_count": "Battery module count",
           "solar_power_max": "Maximum solar power [W]",
           "grid_power_max": "Maximum grid power [W]",
@@ -64,6 +67,7 @@
 		  "calc_solar_power": "Calculation of solar power"
         },
         "data_description": {
+					"inverter_model": "Select the inverter model to use the correct PV startup voltage when filtering phantom string power.",
           "battery_count": "Count of your battery modules.",
           "solar_power_max": "Maximum solar power",
           "grid_power_max": "Maximum grid power",
@@ -76,6 +80,16 @@
       "cannot_connect": "Connection failed – please check IP address and port"
     }
   },
+	"selector": {
+		"inverter_model": {
+			"options": {
+				"powerocean_single_phase": "PowerOcean Single Phase",
+				"powerocean_three_phase": "PowerOcean Three Phase",
+				"powerocean_plus": "PowerOcean Plus",
+				"ocean_2": "Ocean 2"
+			}
+		}
+	},
   "entity":{
 	  "sensor": {
 		  "system_modes":{


### PR DESCRIPTION
https://github.com/MaxGrmm/EF-PowerOcean-TcpModbus/pull/30 configured the voltage threshold to a high 250V, but this will zero out strings with fewer modules than that. We should instead adjust the limit following the data sheets of the inverters and since they have different thresholds, I included a model selection in the config.

The json files had mixed indentations spaces/tabs, so I fixed that. Thus the large line count in the PR.

## Testing

I tested this on my home assistant instance.

<img width="631" height="943" alt="image" src="https://github.com/user-attachments/assets/9c1ee49a-c5cd-4083-b29a-3fb75aad58a0" />
