### PR TITLE
Fix CI running twice on PR pushes

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,7 +2,14 @@ name: Validate
 
 on:
   push:
+    branches:
+      - main
   pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   unit-tests:


### PR DESCRIPTION
## Related Issue

-

## Summary

I saw CI triggered two runs for every push to a PR. This fixes that. Plus it cancels old runs on new pushes.

## Changes

-

## Checklist

- [x] Tests pass (`pytest`)
- [x] CHANGELOG.md updated
- [x] Version bumped in `manifest.json` (if code change)
- [x] README updated (if new sensors, features or behavior changes)
