### PR TITLE
Fix the modbus disabled check when no data is returned

### DIFF
--- a/custom_components/ef_powerocean_tcpmodbus/coordinator.py
+++ b/custom_components/ef_powerocean_tcpmodbus/coordinator.py
@@ -120,9 +120,10 @@ class EcoflowCoordinator(DataUpdateCoordinator):
     @property
     def is_modbus_disabled(self) -> bool:
         """Return whether the current telemetry indicates Modbus is disabled."""
+        data = self.data or {}
         return is_modbus_disabled(
             self.serial_number,
-            self.data.get("inverter_temperature"),
+            data.get("inverter_temperature"),
         )
 
     def get_pymodbus_version(self) -> str:

--- a/custom_components/ef_powerocean_tcpmodbus/coordinator.py
+++ b/custom_components/ef_powerocean_tcpmodbus/coordinator.py
@@ -99,6 +99,7 @@ class EcoflowCoordinator(DataUpdateCoordinator):
         )
 
         self.serial_number: str | None = None
+        self._last_inverter_temperature: float | None = None
         self._client: AsyncModbusTcpClient = AsyncModbusTcpClient(
             host=self.host, port=self.port, timeout=20, reconnect_delay=0, retries=0
         )
@@ -119,11 +120,10 @@ class EcoflowCoordinator(DataUpdateCoordinator):
 
     @property
     def is_modbus_disabled(self) -> bool:
-        """Return whether the current telemetry indicates Modbus is disabled."""
-        data = self.data or {}
+        """Return whether the last telemetry read indicates Modbus is disabled."""
         return is_modbus_disabled(
             self.serial_number,
-            data.get("inverter_temperature"),
+            self._last_inverter_temperature,
         )
 
     def get_pymodbus_version(self) -> str:
@@ -221,6 +221,9 @@ class EcoflowCoordinator(DataUpdateCoordinator):
                         register.size,
                     )
                     data[register.key] = decode_value
+
+            # Store the inverter temperature used for the modbus tcp disabled check, before we do any data validations.
+            self._last_inverter_temperature = data.get("inverter_temperature")
 
             if data["battery_count"] != self.limits[CONF_BATTERY_COUNT]:
                 _LOGGER.debug(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -61,7 +61,7 @@ def test_reports_modbus_disabled_from_current_telemetry(
     expected: bool,
 ) -> None:
     coordinator.serial_number = serial_number
-    coordinator.data = {"inverter_temperature": inverter_temperature}
+    coordinator._last_inverter_temperature = inverter_temperature
 
     assert coordinator.is_modbus_disabled is expected
 
@@ -318,6 +318,33 @@ def test_gets_and_decodes_raw_data(
 
     assert result == {"battery_count": 2.0, "grid_power": 42.0}
     coordinator.async_read_block.assert_awaited_once_with(100, 2)
+
+
+def test_captures_disabled_state_when_battery_count_guard_drops_frame(
+    coordinator, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    block = SimpleNamespace(
+        start_register=100,
+        num_read_regs=2,
+        content=(
+            const.RegisterDef(key="battery_count", block_index=0, size=1),
+            const.RegisterDef(key="inverter_temperature", block_index=1, size=1),
+        ),
+    )
+    monkeypatch.setitem(coordinator_module.MOD_REGISTER_MAP, "blocks", (block,))
+    decode_register = Mock(side_effect=(0.0, 0.0))
+    monkeypatch.setattr(coordinator_module, "decode_register", decode_register)
+    monkeypatch.setattr(coordinator_module.asyncio, "sleep", AsyncMock())
+    coordinator._client = SimpleNamespace(connected=True)
+    coordinator.async_read_block = AsyncMock(return_value=[0, 0])
+    coordinator.limits[const.CONF_BATTERY_COUNT] = 2
+    coordinator.serial_number = "R123456789"
+
+    result = asyncio.run(coordinator.async_get_raw_data())
+
+    assert result is None
+    assert coordinator._last_inverter_temperature == 0.0
+    assert coordinator.is_modbus_disabled is True
 
 
 @pytest.mark.parametrize(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -347,6 +347,39 @@ def test_captures_disabled_state_when_battery_count_guard_drops_frame(
     assert coordinator.is_modbus_disabled is True
 
 
+def test_modbus_disabled_recovers_when_telemetry_returns(
+    coordinator, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    block = SimpleNamespace(
+        start_register=100,
+        num_read_regs=2,
+        content=(
+            const.RegisterDef(key="battery_count", block_index=0, size=1),
+            const.RegisterDef(key="inverter_temperature", block_index=1, size=1),
+        ),
+    )
+    monkeypatch.setitem(coordinator_module.MOD_REGISTER_MAP, "blocks", (block,))
+    # Provide values for two polls, first with all zeroes and second with values
+    decode_register = Mock(side_effect=(0.0, 0.0, 2.0, 21.5))
+    monkeypatch.setattr(coordinator_module, "decode_register", decode_register)
+    monkeypatch.setattr(coordinator_module.asyncio, "sleep", AsyncMock())
+    coordinator._client = SimpleNamespace(connected=True)
+    coordinator.async_read_block = AsyncMock(return_value=[0, 0])
+    coordinator.limits[const.CONF_BATTERY_COUNT] = 2
+    coordinator.serial_number = "R123456789"
+
+    # Run first poll, returning zeros to simulate a Modbus-disabled state.
+    assert asyncio.run(coordinator.async_get_raw_data()) is None
+    assert coordinator.is_modbus_disabled is True
+
+    # Run second poll, returning valid telemetry to simulate recovery.
+    assert asyncio.run(coordinator.async_get_raw_data()) == {
+        "battery_count": 2.0,
+        "inverter_temperature": 21.5,
+    }
+    assert coordinator.is_modbus_disabled is False
+
+
 @pytest.mark.parametrize(
     ("inverter_model", "expected_index"),
     (


### PR DESCRIPTION
## Related Issue

Relates to https://github.com/MaxGrmm/EF-PowerOcean-TcpModbus/issues/46

## Summary

Follow up to https://github.com/MaxGrmm/EF-PowerOcean-TcpModbus/pull/51, which failed to perform the disabled modbus check when the data couldn't be read at all and our battery count guard threw away the full read.

## Changes

-

## Checklist

- [x] Tests pass (`pytest`)
- [x] Added new tests for the new features, and all tests pass successfully
- [x] CHANGELOG.md updated
- [x] Version bumped in `manifest.json` (if code change)
- [x] README updated (if new sensors, features or behavior changes)
