### PR TITLE
Fix unit of ratio in sensor.py

### DIFF
--- a/custom_components/ef_powerocean_tcpmodbus/manifest.json
+++ b/custom_components/ef_powerocean_tcpmodbus/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/MaxGrmm/EF-PowerOcean-TcpModbus/issues",
   "loggers": ["custom_components.ef_powerocean_tcpmodbus"],
   "requirements": [],
-  "version": "2.4.2"
+  "version": "2.4.3"
 }

--- a/custom_components/ef_powerocean_tcpmodbus/sensor.py
+++ b/custom_components/ef_powerocean_tcpmodbus/sensor.py
@@ -15,7 +15,6 @@ from homeassistant.const import (
     UnitOfEnergy,
     UnitOfFrequency,
     UnitOfPower,
-    UnitOfRatio,
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant, callback
@@ -28,6 +27,7 @@ from .const import (
     SENSOR_MAP,
     EnergySensorDef,
     SensorDef,
+    UNIT_OF_RATIO,
 )
 from .coordinator import EcoflowCoordinator
 from .entity import EcoFlowBaseEntity
@@ -36,7 +36,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 VALUE_PRECISION: Final = {
-    UnitOfRatio.PERCENTAGE: 0,
+    UNIT_OF_RATIO: 0,
     UnitOfPower.WATT: 0,
     UnitOfEnergy.KILO_WATT_HOUR: 2,
     UnitOfTemperature.CELSIUS: 1,

--- a/custom_components/ef_powerocean_tcpmodbus/sensor.py
+++ b/custom_components/ef_powerocean_tcpmodbus/sensor.py
@@ -25,9 +25,9 @@ from .const import (
     DOMAIN,
     ENERGY_SENSOR_MAP,
     SENSOR_MAP,
+    UNIT_OF_RATIO,
     EnergySensorDef,
     SensorDef,
-    UNIT_OF_RATIO,
 )
 from .coordinator import EcoflowCoordinator
 from .entity import EcoFlowBaseEntity


### PR DESCRIPTION
## Related Issue

Closes #64 

## Summary

Removes the UnitOfRatio also from sensor.py. Unfortunately that one is not yet covered by tests.

## Changes

-

## Checklist

- [x] Tests pass (`pytest`)
- [x] Added new tests for the new features, and all tests pass successfully
- [x] CHANGELOG.md updated
- [x] Version bumped in `manifest.json` (if code change)
- [x] README updated (if new sensors, features or behavior changes)
