### PR TITLE
Fix battery SOCs defined twice

### DIFF
--- a/custom_components/ef_powerocean_tcpmodbus/const.py
+++ b/custom_components/ef_powerocean_tcpmodbus/const.py
@@ -375,27 +375,6 @@ SENSOR_MAP: list[SensorDef] = [
         state_class="measurement",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    SensorDef(
-        key="soc_battery_1",
-        unit=UNIT_OF_RATIO,
-        device_class="battery",
-        state_class="measurement",
-        entity_category=EntityCategory.DIAGNOSTIC,
-    ),
-    SensorDef(
-        key="soc_battery_2",
-        unit=UNIT_OF_RATIO,
-        device_class="battery",
-        state_class="measurement",
-        entity_category=EntityCategory.DIAGNOSTIC,
-    ),
-    SensorDef(
-        key="soc_battery_3",
-        unit=UNIT_OF_RATIO,
-        device_class="battery",
-        state_class="measurement",
-        entity_category=EntityCategory.DIAGNOSTIC,
-    ),
     *[
         SensorDef(
             key=key,


### PR DESCRIPTION
## Related Issue

Closes #<!-- issue number -->

## Summary

When rebasing in my previous PR, I accidentally introduced duplicate sensors for battery soc 1-3. This removes that.

## Changes

-

## Checklist

- [x] Tests pass (`pytest`)
- [ ] Added new tests for the new features, and all tests pass successfully
- [ ] CHANGELOG.md updated
- [ ] Version bumped in `manifest.json` (if code change)
- [ ] README updated (if new sensors, features or behavior changes)
